### PR TITLE
Fixed a bug with the middleware

### DIFF
--- a/middleware/userSession.js
+++ b/middleware/userSession.js
@@ -6,11 +6,14 @@ module.exports = function (setup) {
 	var module = {};
 	//This nested if stuff is kinda unpleasant and I'd like to fix it
 	module.refresh = function (req, res, next) {
+		console.log(req.originalUrl.split('/')[2])
 		if (!req.session.passport || !req.session.passport.user) {
-			
-			if(req.originalUrl.split('/')[1] == 'internal-api' || req.originalUrl.split('/')[1] == 'api'){
-				res.status(401).send("Not authorised please login to continue. <a href='/auth/provider'>Login</a>");
-				return;
+			let uri = req.originalUrl.split('/');
+			if(uri.length >= 1) {
+				if(uri[1] == 'internal-api' || uri[1] == 'api'){
+					res.status(401).send("Not authorised please login to continue. <a href='/auth/provider'>Login</a>");
+					return;
+				}
 			}
 
 			res.render("statics/login.html");

--- a/middleware/userSession.js
+++ b/middleware/userSession.js
@@ -5,9 +5,14 @@ const users = require('../models/users.js')(setup);
 module.exports = function (setup) {
 	var module = {};
 	//This nested if stuff is kinda unpleasant and I'd like to fix it
-	//TODO: Make middleware for session, isBanned? isWhitelisted?
 	module.refresh = function (req, res, next) {
 		if (!req.session.passport || !req.session.passport.user) {
+			
+			if(req.originalUrl.split('/')[1] == 'internal-api' || req.originalUrl.split('/')[1] == 'api'){
+				res.status(401).send("Not authorised please login to continue. <a href='/auth/provider'>Login</a>");
+				return;
+			}
+
 			res.render("statics/login.html");
 			return;
 		}
@@ -31,9 +36,9 @@ module.exports = function (setup) {
 						req.session.save(function (err) {
 							if (err) log.error("updateUserSession: Error for session.save", { err, 'characterID': user.characterID });
 							next();
-						})	
-					})//End Session Change
-				})
+						});
+					});
+				});
 			}
 		});
 	}

--- a/middleware/userSession.js
+++ b/middleware/userSession.js
@@ -6,7 +6,6 @@ module.exports = function (setup) {
 	var module = {};
 	//This nested if stuff is kinda unpleasant and I'd like to fix it
 	module.refresh = function (req, res, next) {
-		console.log(req.originalUrl.split('/')[2])
 		if (!req.session.passport || !req.session.passport.user) {
 			let uri = req.originalUrl.split('/');
 			if(uri.length >= 1) {


### PR DESCRIPTION
During the session middleware determine if the error is caused while accessing an API.

If it is, we redirect with a status of 401 and send a string with a login button. Otherwise we render the login page.


Hoping this will resolve #10 