### PR TITLE
Hotfix Memory

### DIFF
--- a/models/waitlist.js
+++ b/models/waitlist.js
@@ -8,7 +8,7 @@ module.exports = function (setup) {
     var module = {};
     
     module.get = function (cb) {
-		db.find({}).sort({ "signupTime": 1 }).toArray(function (err, docs) {
+		db.find({}).sort({ "signup": 1 }).toArray(function (err, docs) {
 			if (err) log.error("get: Error for db.find", { err });
             
             for(let i = 0; i < docs.length; i++){

--- a/react/waitlist.js
+++ b/react/waitlist.js
@@ -55,7 +55,7 @@ class Waitlist extends React.Component {
     
     componentDidMount() {
         this.waitlistUpdate();
-        setInterval(this.waitlistUpdate.bind(this), 5 * 1000);
+        setInterval(this.waitlistUpdate.bind(this), 20 * 1000);
     }
 
     getBanner() {


### PR DESCRIPTION
- Reduced the polling time on the waitlist from `5` seconds to `25` seconds. This means people will only get four updates a miniute of the waitlist instead of 30.